### PR TITLE
types: update `TextareaHTMLAttributes` and `InputHTMLAttributes`

### DIFF
--- a/packages/runtime-dom/types/jsx.d.ts
+++ b/packages/runtime-dom/types/jsx.d.ts
@@ -452,6 +452,31 @@ export interface InsHTMLAttributes extends HTMLAttributes {
   datetime?: string
 }
 
+export type InputTypeHTMLAttribute =
+        | 'button'
+        | 'checkbox'
+        | 'color'
+        | 'date'
+        | 'datetime-local'
+        | 'email'
+        | 'file'
+        | 'hidden'
+        | 'image'
+        | 'month'
+        | 'number'
+        | 'password'
+        | 'radio'
+        | 'range'
+        | 'reset'
+        | 'search'
+        | 'submit'
+        | 'tel'
+        | 'text'
+        | 'time'
+        | 'url'
+        | 'week'
+        | (string & {});
+
 export interface InputHTMLAttributes extends HTMLAttributes {
   accept?: string
   alt?: string
@@ -483,7 +508,7 @@ export interface InputHTMLAttributes extends HTMLAttributes {
   size?: Numberish
   src?: string
   step?: Numberish
-  type?: string
+  type?: InputTypeHTMLAttribute
   value?: any // we support :value to be bound to anything w/ v-model
   width?: Numberish
 }
@@ -663,7 +688,7 @@ export interface TextareaHTMLAttributes extends HTMLAttributes {
   minlength?: Numberish
   name?: string
   placeholder?: string
-  readonly?: boolean
+  readonly?: Booleanish
   required?: Booleanish
   rows?: Numberish
   value?: string | string[] | number


### PR DESCRIPTION
add `InputTypeHTMLAttribute` (from `@types/react`) to `InputHTMLAttributes['type' ]`